### PR TITLE
Switch from getInstance() to getSessionFromRequest()

### DIFF
--- a/lib/Util.php
+++ b/lib/Util.php
@@ -10,7 +10,8 @@ class sspmod_selfregister_Util {
 
 
 	public static function checkLoggedAndSameAuth() {
-		$session = SimpleSAML_Session::getInstance();
+        $session = SimpleSAML_Session::getSessionFromRequest();
+
 		if($session->isAuthenticated()) {
 			$uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');
 			/* Get a reference to our authentication source. */

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -10,7 +10,7 @@ class sspmod_selfregister_Util {
 
 
 	public static function checkLoggedAndSameAuth() {
-        $session = SimpleSAML_Session::getSessionFromRequest();
+		$session = SimpleSAML_Session::getSessionFromRequest();
 
 		if($session->isAuthenticated()) {
 			$uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');

--- a/www/index.php
+++ b/www/index.php
@@ -1,7 +1,7 @@
 <?php
 
 $config = SimpleSAML_Configuration::getInstance();
-$session = SimpleSAML_Session::getInstance();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');
 /* Get a reference to our authentication source. */
 $asId = $uregconf->getString('auth');

--- a/www/reviewUser.php
+++ b/www/reviewUser.php
@@ -68,7 +68,7 @@ if(array_key_exists('sender', $_POST)) {
 		// But now atributes from the logged user is obsolete, So I can actualize it and get values from session
 		// but maybe we could have security problem if IdP isnt configured correctly.
 
-		$session = SimpleSAML_Session::getInstance();
+		$session = SimpleSAML_Session::getSessionFromRequest();
 
 		foreach($userInfo as $name => $value) {
 			$attributes[$name][0] = $value;


### PR DESCRIPTION
The method SimpleSAML_Session::getInstance() has been long deprecated and it is now removed. Switch to use the new method getSessionFromRequest().