### PR TITLE
Switch from SimpleSAML_Session::isAuthenticated() to SimpleSAML_Auth_Simple::isAuthenticated()

### DIFF
--- a/lib/Util.php
+++ b/lib/Util.php
@@ -10,14 +10,13 @@ class sspmod_selfregister_Util {
 
 
 	public static function checkLoggedAndSameAuth() {
-		$session = SimpleSAML_Session::getInstance();
-		if($session->isAuthenticated()) {
-			$uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');
-			/* Get a reference to our authentication source. */
-			$asId = $uregconf->getString('auth');
-			if($session->getAuthority() == $asId) {
-				return new SimpleSAML_Auth_Simple($asId);
-			}
+		$session = SimpleSAML_Session::getSessionFromRequest();
+		$uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');
+		$asId = $uregconf->getString('auth');
+
+		$as = new SimpleSAML_Auth_Simple($asId);
+		if ($as->isAuthenticated()) {
+			return $as;
 		}
 		return false;
 	}

--- a/www/index.php
+++ b/www/index.php
@@ -19,35 +19,25 @@ $links = array();
 		'text' => '{selfregister:selfregister:link_lostpw}',
 	);
 
-	if($session->isAuthenticated()) {
-		$uregconf = SimpleSAML_Configuration::getConfig('module_selfregister.php');
-		if($session->getAuthority() == $asId) {
-			$as = new SimpleSAML_Auth_Simple($asId);
 
-			$links[] = array(
-				'href' => SimpleSAML_Module::getModuleURL('selfregister/reviewUser.php'),
-				'text' => '{selfregister:selfregister:link_review}',
-			);
-			$links[] = array(
-				'href' => SimpleSAML_Module::getModuleURL('selfregister/changePassword.php'),
-				'text' => '{selfregister:selfregister:link_changepw}',
-			);
-			$links[] = array(
-				'href' => SimpleSAML_Module::getModuleURL('selfregister/delUser.php'),
-				'text' => '{selfregister:selfregister:link_deluser}',
-			);
-
-			$links[] = array(
-				'href' => $as->getLogoutURL(),
-				'text' => '{status:logout}',
-			);
-		}
-		else {
-			$links[] = array(
-				'href' => SimpleSAML_Module::getModuleURL('selfregister/reviewUser.php'),
-				'text' => '{selfregister:selfregister:link_enter}',
+	$as = new SimpleSAML_Auth_Simple($asId);
+	if ($as->isAuthenticated()) {
+		$links[] = array(
+			'href' => SimpleSAML_Module::getModuleURL('selfregister/reviewUser.php'),
+			'text' => '{selfregister:selfregister:link_review}',
 		);
-		}
+		$links[] = array(
+			'href' => SimpleSAML_Module::getModuleURL('selfregister/changePassword.php'),
+			'text' => '{selfregister:selfregister:link_changepw}',
+		);
+		$links[] = array(
+			'href' => SimpleSAML_Module::getModuleURL('selfregister/delUser.php'),
+			'text' => '{selfregister:selfregister:link_deluser}',
+		);
+		$links[] = array(
+			'href' => $as->getLogoutURL(),
+			'text' => '{status:logout}',
+		);
 	}
 	else {
 		$links[] = array(


### PR DESCRIPTION
The method SimpleSAML_Session::isAuthenticated() has been long deprecated and should be replaced by a call to the same method in SimpleSAML_Auth_Simple.