### PR TITLE
Remove deprecated parameter from call to SimpleSAML_Utilities::generateRandomBytes()

### DIFF
--- a/lib/Storage/SqlMod.php
+++ b/lib/Storage/SqlMod.php
@@ -41,7 +41,7 @@ class sspmod_selfregister_Storage_SqlMod implements iUserCatalogue {
 
 		$this->attributes = $attributes;
 		$this->hashAlgo = $hashAlgo;
-		$this->salt = bin2hex(SimpleSAML_Utilities::generateRandomBytes(64, FALSE));
+		$this->salt = bin2hex(SimpleSAML_Utilities::generateRandomBytes(64));
 		$wc = SimpleSAML_Configuration::loadFromArray($writeConfig);
 		$this->userIdAttr = $wc->getString('user.id.param');
 


### PR DESCRIPTION
The 'fallback' parameter has been long deprecated and is no longer allowed.